### PR TITLE
disabled text color on primary/secondary/tertiary buttons

### DIFF
--- a/framework/source/class/qx/theme/clean/Appearance.js
+++ b/framework/source/class/qx/theme/clean/Appearance.js
@@ -2312,6 +2312,25 @@ qx.Theme.define("qx.theme.clean.Appearance",
     		};
     	}
     },
+
+    "primary-button/label" :
+    {
+        include : "label",
+
+        style : function(states)
+        {
+            if (states.disabled) {
+                return {
+                    textColor : "primary-button-text-disabled"
+                }
+            }
+
+            return {
+                textColor : "primary-button-text"
+            }
+        }
+    },
+
     
     /*
     ---------------------------------------------------------------------------
@@ -2360,7 +2379,25 @@ qx.Theme.define("qx.theme.clean.Appearance",
     },
     
     "secondary-button/icon" : "primary-button/icon",
-    
+
+    "secondary-button/label" :
+    {
+        include : "label",
+
+        style : function(states)
+        {
+            if (states.disabled) {
+                return {
+                    textColor : "secondary-button-text-disabled"
+                }
+            }
+
+            return {
+                textColor : "secondary-button-text"
+            }
+        }
+    },
+
     /*
     ---------------------------------------------------------------------------
       SQv
@@ -2409,7 +2446,24 @@ qx.Theme.define("qx.theme.clean.Appearance",
     
     "tertiary-button/icon" : "primary-button/icon",
     
-    
+    "tertiary-button/label" :
+    {
+        include : "label",
+
+        style : function(states)
+        {
+            if (states.disabled) {
+                return {
+                    textColor : "tertiary-button-text-disabled"
+                }
+            }
+
+            return {
+                textColor : "tertiary-button-text"
+            }
+        }
+    },
+
     "svgbutton" :
     {
       include : "button",

--- a/framework/source/class/qx/theme/clean/Color.js
+++ b/framework/source/class/qx/theme/clean/Color.js
@@ -104,6 +104,7 @@ qx.Theme.define("qx.theme.clean.Color",
 	"primary-button-box-hovered" : "#458ac6",
 	"primary-button-box-pressed" : "#3576ac",
 	"primary-button-text" : "#ffffff",
+	"primary-button-text-disabled" : "#86b3da",
 	
 	//*** SQv Secondary Button colors
 	"secondary-button-box" : "#1b1c1d",
@@ -111,6 +112,7 @@ qx.Theme.define("qx.theme.clean.Color",
 	"secondary-button-box-pressed" : "#0a0a0b",
 	"secondary-button-inset-shadow" : "rgba(39, 41, 43, 0.15)",
 	"secondary-button-text" : "primary-button-text",
+	"secondary-button-text-disabled" : "text-disabled",
 	
 	//*** SQv Tertiary Button colors
 	"tertiary-button-box" : "#5bbd72",
@@ -118,6 +120,7 @@ qx.Theme.define("qx.theme.clean.Color",
 	"tertiary-button-box-pressed" : "#46AE5F",
 	"tertiary-button-inset-shadow" : "rgba(39, 41, 43, 0.15)",
 	"tertiary-button-text" : "primary-button-text",
+	"tertiary-button-text-disabled" : "#a4dbb1",
 	
 	"sqv-black" : qx.core.Environment.get("css.rgba") ? "rgba(0, 0, 0, 1)" : "#000000",
 	"sqv-arrow-gray" : qx.core.Environment.get("css.rgba") ? "rgba(0, 0, 0, 0.6)" : "#444444",


### PR DESCRIPTION
When the primary button is disabled, the text defaults to a gray color, which I don't think looks good on a blue button.  This change lets you specify colors to use for the disabled text.  I like a light blue for the disabled primary button's text and a light green for disabled tertiary button.  The default gray seems to look OK for the secondary button.